### PR TITLE
replaced a non-breaking space (U+00A0) by a normal white space (U+0020)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Tools for running multiple commands or npm scripts in parallel or sequentially.
 - [onchange](https://github.com/Qard/onchange) - `onchange <glob> -- <command>`.
 - [watch](https://github.com/mikeal/watch) - `watch <command> <directory>`.
 
-## Dev Servers
+## Dev Servers
 
 - [http-server](https://github.com/indexzero/http-server) - A simple zero-configuration command-line http server.
 - [live-server](https://github.com/tapio/live-server) - Simple development http server with live reload capability.


### PR DESCRIPTION
fixing the issue with the doctoc script spotted in https://github.com/RyanZim/awesome-npm-scripts/pull/5#issuecomment-252244004
and reported at https://github.com/thlorenz/doctoc/issues/121
