### PR TITLE
Add cpy-cli to copy/rename files

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Tools for running multiple commands or npm scripts in parallel or sequentially.
 - [rimraf](https://github.com/isaacs/rimraf) - Cross-platform `rm -rf`.
 - [del-cli](https://github.com/sindresorhus/del-cli) - Safer file and folder deletion.
 - [mkdirp](https://github.com/substack/node-mkdirp) - Cross-platform `mkdir -p`.
+- [cpy-cli](https://github.com/sindresorhus/cpy-cli) - Cross-platform file/directory copying/renaming.
 - [copyfiles](https://github.com/calvinmetcalf/copyfiles) - Cross-platform file copying.
 - [sync-files](https://github.com/byteclubfr/node-sync-files) - Cross-platform `rsync`-like directory syncing with watch mode.
 - [echo-cli](https://github.com/iamakulov/echo-cli) - Cross-platform `echo` with JS escape sequence support.


### PR DESCRIPTION
I tried using [copyfiles](https://github.com/calvinmetcalf/copyfiles), which worked fine for copying - but not renaming (or copying with a new name).
[cpy-cli](https://github.com/sindresorhus/cpy-cli) supports that.