### PR TITLE
Add ncp - async recursive file & directory copying in node and cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Tools for running multiple commands or npm scripts in parallel or sequentially.
 - [rimraf](https://github.com/isaacs/rimraf) - Cross-platform `rm -rf`.
 - [del-cli](https://github.com/sindresorhus/del-cli) - Safer file and folder deletion.
 - [mkdirp](https://github.com/substack/node-mkdirp) - Cross-platform `mkdir -p`.
+- [ncp](https://github.com/AvianFlu/ncp) - Asynchronous recursive file & directory copying in node and cli.
 - [cpy-cli](https://github.com/sindresorhus/cpy-cli) - Cross-platform file/directory copying/renaming.
 - [copyfiles](https://github.com/calvinmetcalf/copyfiles) - Cross-platform file copying.
 - [sync-files](https://github.com/byteclubfr/node-sync-files) - Cross-platform `rsync`-like directory syncing with watch mode.


### PR DESCRIPTION
Following up my last PR, `cpy-cli` disappointed me when I had to recursively copy directories. This is where `ncp` delivers. I'd even go as far as removing `cpy-cli` and `copyfiles` to prevent people from wasting time like I had to.