### PR TITLE
Add cli-error-notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Utilities to perform common command-line tasks without worrying about cross-plat
 - [cross-os](https://github.com/milewski/cross-os) - Run platform-specific npm scripts.
 - [ntee](https://github.com/stefanmaric/ntee) - Utility that reads from standard input and writes to standard output and files; like Unix `tee`.
 - [catw](https://github.com/substack/catw) - Print a file to stdout, with optional watch mode; sorta like Unix `cat`.
+- [cli-error-notifier](https://github.com/micromata/cli-error-notifier) - Send native desktop notifications when npm scripts fail.
 
 ### Utility Packs
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Utilities to perform common command-line tasks without worrying about cross-plat
 - [cross-os](https://github.com/milewski/cross-os) - Run platform-specific npm scripts.
 - [ntee](https://github.com/stefanmaric/ntee) - Utility that reads from standard input and writes to standard output and files; like Unix `tee`.
 - [catw](https://github.com/substack/catw) - Print a file to stdout, with optional watch mode; sorta like Unix `cat`.
-- [cli-error-notifier](https://github.com/micromata/cli-error-notifier) - Send native desktop notifications when npm scripts fail.
 
 ### Utility Packs
 
@@ -91,6 +90,7 @@ Utilities to perform common command-line tasks without worrying about cross-plat
 - [opn-cli](https://github.com/sindresorhus/opn-cli) - Open websites, files, executables, etc. with the user's preferred application.
 - [headr](https://github.com/heldr/headr) - Add header / banner info to a file.
 - [Bower files CLI](https://github.com/thompsonemerson/bower-files-cli) - Get main bower files on the command line
+- [cli-error-notifier](https://github.com/micromata/cli-error-notifier) - Send native desktop notifications when npm scripts fail.
 
 ## Miscellaneous
 


### PR DESCRIPTION
Addition:

[cli-error-notifier](https://github.com/micromata/cli-error-notifier) - Sends native desktop notifications when npm scripts fail.

Cheers, Michael 