### PR TITLE
Use title case for heading

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 <!--lint ignore awesome-heading-->
-# Awesome npm scripts [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+# Awesome npm Scripts [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 [<img src="npm-logo.png" align="right" width="150">](https://www.npmjs.com)
 


### PR DESCRIPTION
npm can't be capitalized, so we have to keep the linter ignore rule; but this fixes the heading otherwise